### PR TITLE
Loading Incident store

### DIFF
--- a/kai/__init__.py
+++ b/kai/__init__.py
@@ -78,12 +78,13 @@ def generate(
 
 
 @app.command()
-def load(apps: list):
+def load(applications: str):
     """
     Load the incident store with the given applications
     write the cached_violations to a file for later use
     """
     incident_store = IncidentStore()
+    apps = applications.split(",")
     print(f"Loading incident store with {len(apps)} applications\n")
     cached_violations = incident_store.load_app_cached_violation(apps)
     print("Writing cached_violations")

--- a/kai/__init__.py
+++ b/kai/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "0.0.1"
 
-from typing import List, Optional
+from typing import List
 
 import typer
 from typing_extensions import Annotated
@@ -86,5 +86,5 @@ def load(apps: list):
     incident_store = IncidentStore()
     print(f"Loading incident store with {len(apps)} applications\n")
     cached_violations = incident_store.load_app_cached_violation(apps)
-    print(f"Writing cached_violations")
+    print("Writing cached_violations")
     incident_store.write_cached_violations(cached_violations)

--- a/kai/incident_store.py
+++ b/kai/incident_store.py
@@ -84,6 +84,7 @@ class IncidentStore:
                        file_path: [ {
                             variables: {}
                             line_number: int
+                            message: str
                         } ]
                     }
                }

--- a/kai/incident_store.py
+++ b/kai/incident_store.py
@@ -1,0 +1,292 @@
+__all__ = ["Application", "IncidentStore"]
+
+import copy
+import os
+import pprint
+
+import yaml
+
+from kai.report import Report
+
+
+class Application:
+    def __init__(
+        self,
+        name,
+        report,
+        repo=None,
+        initial_branch=None,
+        solved_branch=None,
+        commitId=None,
+        timestamp=None,
+    ):
+        self.name = name
+        self.report = report
+        self.repo = repo
+        self.initial_branch = initial_branch
+        self.solved_branch = solved_branch
+        self.commitId = commitId
+        self.timestamp = timestamp
+
+
+class IncidentStore:
+    def __init__(self):
+        # applications, keyed on App Name
+        self.applications = {}
+        # cached_violations is defined in comments in self._update_cached_violations
+        self.cached_violations = {}
+        self.pp = pprint.PrettyPrinter(indent=2)
+
+    def add_app_to_incident_store(self, app_name, yaml):
+        r = Report(yaml).get_report()
+        a = Application(name=app_name, report=r)
+        self.applications[app_name] = a
+        self._update_cached_violations(a)
+
+    def get_app_from_incident_store(self, app_name):
+        return self.applications[app_name]
+
+    def get_app_names_from_incident_store(self):
+        return self.applications.keys()
+
+    # todo query hub api for the application
+    def get_app_from_konveyor_hub(self, name):
+        # query hub api for the application
+        # return the application
+        if self.applications[name] is None:
+            return None
+        else:
+            app = self.applications[name]
+            # todo: query hub api for the application
+            # populate the application with the hub api data
+            return app
+
+    # determine if new application analysis report is available
+    def is_new_analysis_report_available(self, application):
+        # query hub api for the application
+        # if the timestamp is newer than the current timestamp
+        # return true
+        # else return false
+        app1 = self.get_app_from_konveyor_hub(application.name)
+        if app1 is not None:
+            if app1.timestamp > application.timestamp:
+                return True
+        return False
+
+    def _update_cached_violations(self, a):
+        """
+        Update the cached_violations with the new application
+        The desired structure
+         cached_violations: {
+           ruleset_name: {
+               violation_name: {
+                   app_name: {
+                       file_path: [ {
+                            variables: {}
+                            line_number: int
+                        } ]
+                    }
+               }
+           }
+         }
+
+        """
+        ### Add our Application's Name to the cached_violations
+        # self.pp.pprint(a.report)
+
+        for ruleset in a.report.keys():
+            if ruleset not in self.cached_violations:
+                self.cached_violations[ruleset] = {}
+            for violation_name in a.report[ruleset]["violations"].keys():
+                if violation_name not in self.cached_violations[ruleset]:
+                    self.cached_violations[ruleset][violation_name] = {}
+                # Assume there can be multiple incidents of the same violation in same file
+                ## Example of the YAML report data for an incident
+                ##  incidents:
+                ##  - uri: file:///tmp/source-code/src/main/webapp/WEB-INF/web.xml
+                ##    message: "\n Session replication ensures that client sessions are not disrupted by node failure.
+                ##             Each node in the cluster shares information about ongoing sessions and can take over sessions
+                ##             if another node disappears. In a cloud environment, however, data in the memory of a running container can be wiped out by a restart.\n\n
+                ##             Recommendations\n\n * Review the session replication usage and ensure that it is configured properly.\n *
+                ##             Disable HTTP session clustering and accept its implications.\n * Re-architect the application so that sessions are stored in a cache backing service or a remote data grid.\n\n
+                ##             A remote data grid has the following benefits:\n\n * The application is more scaleable and elastic.\n * The application can survive EAP node failures
+                ##             because a JVM failure does not cause session data loss.\n * Session data can be shared by multiple applications.\n "
+                ##    variables:
+                ##      data: distributable
+                ##      innerText: ""
+                ##      matchingXML: ""
+                ##
+                incidents = a.report[ruleset]["violations"][violation_name].get(
+                    "incidents", None
+                )
+                if incidents is None:
+                    # self.pp.pprint(a.report[ruleset]["violations"])
+                    print(
+                        f"Found no incidents for '{a.name}' with {ruleset} and {violation_name}"
+                    )
+                    continue
+                for incident in incidents:
+                    if a.name not in self.cached_violations[ruleset][violation_name]:
+                        self.cached_violations[ruleset][violation_name][a.name] = {}
+                    uri = incident.get("uri", None)
+                    if uri is None:
+                        # self.pp.pprint(incident)
+                        print(
+                            f"'{a.name}' with {ruleset} and {violation_name}, incident has no 'uri'"
+                        )
+                        continue
+                    file_path = Report.get_cleaned_file_path(uri)
+                    if (
+                        file_path
+                        not in self.cached_violations[ruleset][violation_name][a.name]
+                    ):
+                        self.cached_violations[ruleset][violation_name][a.name][
+                            file_path
+                        ] = []
+                    # Remember for future matches we need to take into account the variables
+                    entry = {
+                        "variables": copy.deepcopy(incident.get("variables", {})),
+                        "line_number": incident.get("lineNumber", None),
+                        "message": incident.get("message", None),
+                    }
+                    self.cached_violations[ruleset][violation_name][a.name][
+                        file_path
+                    ].append(entry)
+
+    def find_common_violations(self, ruleset_name, violation_name):
+        """
+        Find the common violation across all applications
+        Returns:
+            None        - if no common violation
+            {}          - if a common violation is found
+        """
+        if self.cached_violations is None:
+            return None
+        ruleset = self.cached_violations.get(ruleset_name, None)
+        if ruleset is None:
+            print(f"Unable to find cached_violations for ruleset: '{ruleset_name}'")
+            return None
+        entry = self.cached_violations[ruleset_name].get(violation_name, None)
+        if entry is None:
+            print(
+                f"Unable to find a match of ruleset: '{ruleset_name}' and violation_name: '{violation_name}'"
+            )
+            return None
+        # print(f"Found a match of ruleset: '{ruleset_name}' and violation_name: '{violation_name}': entry is '{entry}'")
+        # print(f"DeepCopy = {copy.deepcopy(entry)}")
+        # Make   a deepcopy of entries
+        return copy.deepcopy(entry)
+
+    def load_app_cached_violation(self, apps):
+        """
+        Load the incident store with the given applications
+        """
+
+        print(f"Loading incident store with {len(apps)} applications\n")
+        for app in apps:
+            print(f"Loading application {app}\n")
+            output_yaml = self.fetch_output_yaml(app)
+            if output_yaml is None:
+                print(f"Error: output.yaml does not exist for {app}.")
+                return None
+            self.add_app_to_incident_store(app, output_yaml)
+        print(f"Loaded incident store with {len(apps)} applications\n")
+        return self.cached_violations
+
+    def fetch_output_yaml(self, app_name):
+        """
+        Fetch the output and app yaml for the given application
+        """
+        # Path to the analysis_reports directory
+        analysis_reports_dir = "samples/analysis_reports"
+
+        # Check if the specified app folder exists
+        app_folder = os.path.join(analysis_reports_dir, app_name)
+        if not os.path.exists(app_folder):
+            print(
+                f"Error: {app_name} does not exist in the analysis_reports directory."
+            )
+            return None
+
+        # Path to the output.yaml file
+        output_yaml_path = os.path.join(app_folder, "output.yaml")
+
+        # Check if output.yaml exists for the specified app
+        if not os.path.exists(output_yaml_path):
+            print(f"Error: output.yaml does not exist for {app_name}.")
+            return None
+
+        return output_yaml_path
+
+    def write_cached_violations(self, cached_violations):
+        """
+        Write the cached_violations to a file for later use
+        """
+
+        output_directory = "samples/generated_output/incident_store"
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        parent_dir = os.path.dirname(dir_path)
+        os.path.join(parent_dir, output_directory)
+        os.makedirs(
+            output_directory, exist_ok=True
+        )  # Create the directory if it doesn't exist
+        output_file_path = os.path.join(output_directory, "cached_violations.yaml")
+
+        print(f"Writing incident store to file: {output_file_path}")
+
+        with open(output_file_path, "w") as f:
+            yaml.dump(cached_violations, f)
+        print(f"Written cached_violations to {output_file_path}\n")
+
+    # determine if new application analysis report is available
+    def is_new_analysis_report_available(application):
+        # query hub api for the application
+        # if the timestamp is newer than the current timestamp
+        # return true
+        # else return false
+        app1 = IncidentStore.get_app_from_konveyor_hub(application.name)
+        if app1 is not None:
+            if app1.timestamp > application.timestamp:
+                return app1.timestamp
+        return None
+
+    # update the timestamp in app.yaml if new analysis report is available
+    # It is a WORKAROUND until we retrieve data from the hub api
+    def update_timestamp(application):
+        # query hub api for the application
+        # if the timestamp is newer than the current timestamp
+        # update the timestamp in app.yaml
+        # return true
+        # else return false
+        if IncidentStore.is_new_analysis_report_available(application) is not None:
+            # update the timestamp in app.yaml
+            # Path to the analysis_reports directory
+            analysis_reports_dir = "samples/analysis_reports"
+
+            # Check if the specified app folder exists
+            app_folder = os.path.join(analysis_reports_dir, application.name)
+            if not os.path.exists(app_folder):
+                print(
+                    f"Error: {application.name} does not exist in the analysis_reports directory."
+                )
+                return False
+
+            # Load contents of app.yaml
+            app_yaml_path = os.path.join(app_folder, "app.yaml")
+            if not os.path.exists(app_yaml_path):
+                print(f"Error: app.yaml does not exist for {application.name}.")
+                return False
+            # open the file in write mode and update the timestamp field
+            with open(app_yaml_path, "r") as app_yaml_file:
+                app_yaml_data = yaml.safe_load(app_yaml_file)
+
+            # Update the timestamp in the app.yaml data
+            app_yaml_data["timestamp"] = application.timestamp
+
+            # Write the updated contents back to app.yaml
+            with open(app_yaml_path, "w") as app_yaml_file:
+                yaml.dump(app_yaml_data, app_yaml_file)
+
+            # Return true
+            return True
+        return False

--- a/tests/test_incident_store.py
+++ b/tests/test_incident_store.py
@@ -21,17 +21,6 @@ class TestIncidentStore(unittest.TestCase):
         # Test when the specified app folder does not exist
         i = IncidentStore()
         app_name = "non_existing_app"
-        expected_output = (
-            f"Error: {app_name} does not exist in the analysis_reports directory."
-        )
-        yaml = i.fetch_output_yaml(app_name)
-        self.assertIsNone(yaml)
-
-    def test_fetch_output_yaml_missing_output_yaml(self):
-        # Test when output.yaml does not exist for the specified app
-        i = IncidentStore()
-        app_name = "missing_output_yaml_app"
-        expected_output = f"Error: output.yaml does not exist for {app_name}."
         yaml = i.fetch_output_yaml(app_name)
         self.assertIsNone(yaml)
 

--- a/tests/test_incident_store.py
+++ b/tests/test_incident_store.py
@@ -1,0 +1,243 @@
+import os
+import unittest
+
+import yaml
+
+from kai.incident_store import Application, IncidentStore
+
+
+class TestIncidentStore(unittest.TestCase):
+
+    def test_fetch_output_yaml_existing_app_output_yaml(self):
+        # Test when the specified app folder and output.yaml exist
+        i = IncidentStore()
+        app_name = "kitchensink"
+        expected_output_yaml_path = os.path.join(
+            "samples/analysis_reports", app_name, "output.yaml"
+        )
+        self.assertEqual(i.fetch_output_yaml(app_name), expected_output_yaml_path)
+
+    def test_fetch_output_yaml_non_existing_app(self):
+        # Test when the specified app folder does not exist
+        i = IncidentStore()
+        app_name = "non_existing_app"
+        expected_output = (
+            f"Error: {app_name} does not exist in the analysis_reports directory."
+        )
+        yaml = i.fetch_output_yaml(app_name)
+        self.assertIsNone(yaml)
+
+    def test_fetch_output_yaml_missing_output_yaml(self):
+        # Test when output.yaml does not exist for the specified app
+        i = IncidentStore()
+        app_name = "missing_output_yaml_app"
+        expected_output = f"Error: output.yaml does not exist for {app_name}."
+        yaml = i.fetch_output_yaml(app_name)
+        self.assertIsNone(yaml)
+
+    def test_update_cached_violations_no_incidents(self):
+        # Test when there are no incidents in the report
+
+        name = "sample"
+        report = {
+            "cloud-readiness": {
+                "name": "cloud-readiness",
+                "description": "This ruleset detects logging configurations that may be problematic when migrating an application to a cloud environment.",
+                "violations": {
+                    "session-00000": {
+                        "description": "HTTP session replication (distributable web.xml)",
+                        "category": "mandatory",
+                        "labels": [
+                            "clustering",
+                            "konveyor.io/source=java",
+                            "konveyor.io/source=java-ee",
+                            "konveyor.io/target=cloud-readiness",
+                        ],
+                        "incidents": None,
+                        "effort": 3,
+                    }
+                },
+            }
+        }
+
+        a = Application(name, report)
+        i = IncidentStore()
+        i._update_cached_violations(a)
+        # Assert that the cached_violations remains unchanged
+        self.assertEqual(i.cached_violations["cloud-readiness"]["session-00000"], {})
+
+    def test_update_cached_violations_with_incidents(self):
+        # Test when there are incidents in the report
+
+        name = "sample"
+        report = {
+            "cloud-readiness": {
+                "name": "cloud-readiness",
+                "description": "This ruleset detects logging configurations that may be problematic when migrating an application to a cloud environment.",
+                "violations": {
+                    "session-00000": {
+                        "description": "HTTP session replication (distributable web.xml)",
+                        "category": "mandatory",
+                        "labels": [
+                            "clustering",
+                            "konveyor.io/source=java",
+                            "konveyor.io/source=java-ee",
+                            "konveyor.io/target=cloud-readiness",
+                        ],
+                        "incidents": [
+                            {
+                                "uri": "file:///tmp/source-code/webapp/WEB-INF/web.xml",
+                                "message": "\n Session replication ensures that client sessions are not disrupted by node failure. Each node in the cluster shares information about ongoing sessions and can take over sessions if another node disappears. In a cloud environment, however, data in the memory of a running container can be wiped out by a restart.\n\n Recommendations\n\n * Review the session replication usage and ensure that it is configured properly.\n * Disable HTTP session clustering and accept its implications.\n * Re-architect the application so that sessions are stored in a cache backing service or a remote data grid.\n\n A remote data grid has the following benefits:\n\n * The application is more scaleable and elastic.\n * The application can survive EAP node failures because a JVM failure does not cause session data loss.\n * Session data can be shared by multiple applications.\n ",
+                                "variables": {
+                                    "data": "distributable",
+                                    "innerText": "",
+                                    "matchingXML": "",
+                                },
+                            }
+                        ],
+                        "effort": 3,
+                    }
+                },
+            }
+        }
+
+        a = Application(name, report)
+        i = IncidentStore()
+        i._update_cached_violations(a)
+        # Assert that the cached_violations is updated correctly
+        expected_cached_violations = {
+            "cloud-readiness": {
+                "session-00000": {
+                    "sample": {
+                        "webapp/WEB-INF/web.xml": [
+                            {
+                                "variables": {
+                                    "data": "distributable",
+                                    "innerText": "",
+                                    "matchingXML": "",
+                                },
+                                "line_number": None,
+                                "message": "\n Session replication ensures that client sessions are not disrupted by node failure. Each node in the cluster shares information about ongoing sessions and can take over sessions if another node disappears. In a cloud environment, however, data in the memory of a running container can be wiped out by a restart.\n\n Recommendations\n\n * Review the session replication usage and ensure that it is configured properly.\n * Disable HTTP session clustering and accept its implications.\n * Re-architect the application so that sessions are stored in a cache backing service or a remote data grid.\n\n A remote data grid has the following benefits:\n\n * The application is more scaleable and elastic.\n * The application can survive EAP node failures because a JVM failure does not cause session data loss.\n * Session data can be shared by multiple applications.\n ",
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        self.assertEqual(i.cached_violations, expected_cached_violations)
+
+    def test_load_app_cached_violation(self):
+        # Test when the specified app folder and output.yaml exist
+        apps = [
+            "kitchensink",
+            "eap-coolstore-monolith",
+            "helloworld-mdb",
+            "ticket-monster",
+        ]
+        i = IncidentStore()
+
+        i.load_app_cached_violation(apps)
+        self.assertIsNotNone(i.cached_violations)
+        self.assertIsInstance(i.cached_violations, dict)
+        self.assertEqual(len(i.cached_violations), 6)
+
+    def test_write_cached_violations(self):
+        test_cached_violations = {
+            "cloud-readiness": {
+                "session-00000": {
+                    "eap-coolstore-monolith": {
+                        "webapp/WEB-INF/web.xml": [
+                            {
+                                "variables": {
+                                    "data": "distributable",
+                                    "innerText": "",
+                                    "matchingXML": "",
+                                },
+                                "line_number": None,
+                                "message": "\n Session replication ensures that client sessions are not disrupted by node failure. Each node in the cluster shares information about ongoing sessions and can take over sessions if another node disappears. In a cloud environment, however, data in the memory of a running container can be wiped out by a restart.\n\n Recommendations\n\n * Review the session replication usage and ensure that it is configured properly.\n * Disable HTTP session clustering and accept its implications.\n * Re-architect the application so that sessions are stored in a cache backing service or a remote data grid.\n\n A remote data grid has the following benefits:\n\n * The application is more scaleable and elastic.\n * The application can survive EAP node failures because a JVM failure does not cause session data loss.\n * Session data can be shared by multiple applications.\n ",
+                            }
+                        ]
+                    }
+                }
+            },
+            "localhost-http-00001": {
+                "ticket-monster": {
+                    "backend-v2/src/main/java/org/jboss/examples/ticketmonster/rest/BookingService.java": [
+                        {
+                            "variables": {
+                                "matchingText": 'http://localhost:9090/rest/bookings"'
+                            },
+                            "line_number": 57,
+                            "message": "The app is trying to access local resource by HTTP, please try to migrate the resource to cloud",
+                        }
+                    ],
+                    "orders-service/src/test/java/org/ticketmonster/orders/SimpleTest.java": [
+                        {
+                            "variables": {"matchingText": "http://localhost"},
+                            "line_number": 49,
+                            "message": "The app is trying to access local resource by HTTP, please try to migrate the resource to cloud",
+                        }
+                    ],
+                }
+            },
+            "localhost-jdbc-00002": {
+                "ticket-monster": {
+                    "orders-service/src/main/resources/application-mysql.properties": [
+                        {
+                            "variables": {
+                                "matchingText": "jdbc:mysql://localhost:3306"
+                            },
+                            "line_number": 1,
+                            "message": "The app is trying to access local resource by JDBC, please try to migrate the resource to cloud",
+                        },
+                        {
+                            "variables": {
+                                "matchingText": "jdbc:mysql://localhost:3306"
+                            },
+                            "line_number": 6,
+                            "message": "The app is trying to access local resource by JDBC, please try to migrate the resource to cloud",
+                        },
+                    ],
+                    "orders-service/target/classes/application-mysql.properties": [
+                        {
+                            "variables": {
+                                "matchingText": "jdbc:mysql://localhost:3306"
+                            },
+                            "line_number": 1,
+                            "message": "The app is trying to access local resource by JDBC, please try to migrate the resource to cloud",
+                        },
+                        {
+                            "variables": {
+                                "matchingText": "jdbc:mysql://localhost:3306"
+                            },
+                            "line_number": 6,
+                            "message": "The app is trying to access local resource by JDBC, please try to migrate the resource to cloud",
+                        },
+                    ],
+                }
+            },
+        }
+
+        output_directory = "samples/generated_output/incident_store"
+        output_file_path = os.path.join(output_directory, "cached_violations.yaml")
+        i = IncidentStore()
+        try:
+            # Call the function under test
+            i.write_cached_violations(test_cached_violations)
+
+            # Check if the file was created
+            print(output_file_path)
+            self.assertTrue(os.path.exists(output_file_path))
+
+            # Check if the written data matches the expected data
+            with open(output_file_path, "r") as f:
+                loaded_data = yaml.safe_load(f)
+            self.assertEqual(loaded_data, test_cached_violations)
+
+        finally:
+            # Clean up
+            if os.path.exists(output_file_path):
+                os.remove(output_file_path)
+
+    if __name__ == "__main__":
+        unittest.main()


### PR DESCRIPTION
My first stab at incident store

1. There is a load method that takes the list of applications and loads the cached violations data store.
Sample command to run `./run_cli.py load kitchensink,eap-coolstore-monolith`

2. writes to `samples/generated_output/incident_store/cached_violations.yaml`