### PR TITLE
Bump github actions check to address deprecated warning

### DIFF
--- a/.github/workflows/trunk-check-annotations.yml
+++ b/.github/workflows/trunk-check-annotations.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@main
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@main
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1


### PR DESCRIPTION
Addresses: 

"Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/."

https://github.com/konveyor-ecosystem/kai/actions/runs/7729866097
