### PR TITLE
Set aiohttp version based on python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-aiohttp==3.8.6
+aiohttp==3.8.6; python_version < '3.12'
+aiohttp==3.9.3; python_version >= '3.12'
 aiolimiter==1.1.0
 aiosignal==1.3.1
 annotated-types==0.6.0


### PR DESCRIPTION
Fedora 39 uses python 3.12. aiohttp 3.8.6 does not work with it.