### PR TITLE
Restore run_tests.sh to run without an errors

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,8 +1,11 @@
 #/usr/bin/sh
 #
+
+export PYTHONPATH="$(pwd)/kai:${PYTHONPATH}" # trunk-ignore(shellcheck)
 python -m unittest -v
 
 ##
+# Example to run tests in a single test class:
+# python -m unittest -v tests.test_incident_store_advanced.TestIncidentStoreAdvanced
 # Example to run a single test:
-# $ python -m unittest -v tests.test_incident_store.TestIncidentStore.test_find_solved_issues
-#
+# python -m unittest -v tests.test_incident_store.TestIncidentStore.test_find_solved_issues

--- a/tests/test_incident_store.py
+++ b/tests/test_incident_store.py
@@ -243,7 +243,7 @@ class TestIncidentStore(unittest.TestCase):
             "quarkus/springboot", "javaee-pom-to-quarkus-00010"
         )
         self.assertIsNotNone(patches)
-        self.assertEquals(len(patches), 1)
+        self.assertEqual(len(patches), 1)
         self.incident_store.cleanup()
 
     def test_find_solved_issues_no_solved_issues(self):


### PR DESCRIPTION
I wasn't able to run unit tests today, noticed 2 failures that needed a tweak to address

