### PR TITLE
Capturing reasoning info and writing to disk plus small tweaks to client for logging and gathering timing info

### DIFF
--- a/example/run_demo.py
+++ b/example/run_demo.py
@@ -159,7 +159,9 @@ def write_to_disk(file_path, updated_file_contents):
 
 def process_file(file_path, violations, num_impacted_files, count):
     start = time.time()
-    KAI_LOG.info(f"File #{count} of {num_impacted_files} - Processing {file_path} which has {len(violations)} violations")
+    KAI_LOG.info(
+        f"File #{count} of {num_impacted_files} - Processing {file_path} which has {len(violations)} violations"
+    )
     # TODO: Revisit processing non Java files
     if not file_path.endswith(".java"):
         KAI_LOG.warning(f"Skipping {file_path} as it is not a Java file")
@@ -167,13 +169,12 @@ def process_file(file_path, violations, num_impacted_files, count):
 
     params = collect_parameters(file_path, violations)
     response = generate_fix(params)
-    KAI_LOG.info(
-        f"Response StatusCode: {response.status_code} for {file_path}\n"
-    )
+    KAI_LOG.info(f"Response StatusCode: {response.status_code} for {file_path}\n")
     updated_file_contents = parse_response(response)
     write_to_disk(file_path, updated_file_contents)
     end = time.time()
     return f"{end-start}s to process {file_path} with {len(violations)} violations"
+
 
 def run_demo(report):
     impacted_files = report.get_impacted_files()
@@ -192,7 +193,7 @@ def run_demo(report):
             )
             futures.append(future)
 
-        for future in futures:
+        for future in as_completed(futures):
             try:
                 result = future.result()
                 KAI_LOG.info(f"Result:  {result}")
@@ -203,8 +204,12 @@ def run_demo(report):
                 f"{remaining_files} files remaining from total of {num_impacted_files}"
             )
 
+
 if __name__ == "__main__":
     KAI_LOG.setLevel("info".upper())
+    start = time.time()
     coolstore_analysis_dir = "./analysis/coolstore/output.yaml"
     r = Report(coolstore_analysis_dir)
     run_demo(r)
+    end = time.time()
+    KAI_LOG.info(f"Total time to process '{coolstore_analysis_dir}' was {end-start}s")

--- a/example/run_demo.py
+++ b/example/run_demo.py
@@ -3,7 +3,8 @@
 import json
 import os
 import sys
-from concurrent.futures import ThreadPoolExecutor
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 
 import requests
@@ -18,9 +19,8 @@ APP_NAME = "coolstore"
 SAMPLE_APP_DIR = "./coolstore"
 
 # TODOs
-# 1) Add ConfigFile to tweak the server URL an rulesets/violations
+# 1) Add ConfigFile to tweak the server URL and rulesets/violations
 # 2) Limit to specific rulesets/violations we are interested in
-# 3) Save the updated file to disk
 
 
 @dataclass
@@ -76,9 +76,11 @@ def collect_parameters(file_path, violations) -> KaiRequestParams:
 
 def _generate_fix(params: KaiRequestParams):
     headers = {"Content-type": "application/json", "Accept": "text/plain"}
-    ## We will timeout in 10 minutes if we do not receive a reply
     response = requests.post(
+        ###
+        # If we are sending only one incident, we can use this endpoint
         # f"{SERVER_URL}/get_incident_solution",
+        ###
         f"{SERVER_URL}/get_incident_solutions_for_file",
         data=params.to_json(),
         headers=headers,
@@ -95,19 +97,28 @@ def generate_fix(params: KaiRequestParams):
             if response.status_code == 200:
                 return response
             else:
-                print(f"Received status code {response.status_code}")
+                KAI_LOG.info(
+                    f"[{params.file_name}] Received status code {response.status_code}"
+                )
         except requests.exceptions.RequestException as e:
-            print(f"Received exception: {e}")
+            KAI_LOG.error(f"[{params.file_name}] Received exception: {e}")
             # This is what a timeout exception will look like:
             # requests.exceptions.ReadTimeout: HTTPConnectionPool(host='0.0.0.0', port=8080): Read timed out. (read timeout=600)
-        print(
-            f"Failed to get a '200' response from the server.  Retrying {retries_left-i} more times"
+        KAI_LOG.error(
+            f"[{params.file_name}] Failed to get a '200' response from the server.  Retrying {retries_left-i} more times"
         )
-    sys.exit(f"Failed to get a '200' response from the server.  Parameters = {params}")
+    sys.exit(
+        f"[{params.file_name}] Failed to get a '200' response from the server.  Parameters = {params}"
+    )
 
 
 def parse_response(response):
-    return response.json()
+    try:
+        return response.json()
+    except Exception as e:
+        KAI_LOG.error(f"Failed to parse response with error: {e}")
+        KAI_LOG.error(f"Response: {response}")
+        sys.exit(1)
     ## TODO:  Below is rough guess at error handling, need to confirm
     # if "error" in response_json:
     #    print(f"Error: {response_json['error']}")
@@ -120,41 +131,60 @@ def write_to_disk(file_path, updated_file_contents):
     # We expect that we are overwriting the file, so all directories should exist
     intended_file_path = f"{SAMPLE_APP_DIR}/{file_path}"
     if not os.path.exists(intended_file_path):
-        print(
+        KAI_LOG.warning(
             f"**WARNING* File {intended_file_path} does not exist.  Proceeding, but suspect this is a new file or there is a problem with the filepath"
         )
 
-    print(f"Writing to {intended_file_path}")
-    # print(f"{updated_file_contents['updated_file']}")
-    # print(f"Reasoning: {updated_file_contents['total_reasoning']}")
-    with open(intended_file_path, "w") as f:
-        f.write(updated_file_contents["updated_file"])
+    KAI_LOG.info(f"Writing updated source code to {intended_file_path}")
+    try:
+        with open(intended_file_path, "w") as f:
+            f.write(updated_file_contents["updated_file"])
+    except Exception as e:
+        KAI_LOG.error(
+            f"Failed to write updated_file @ {intended_file_path} with error: {e}"
+        )
+        KAI_LOG.error(f"Contents: {updated_file_contents}")
+        sys.exit(1)
+
+    reasoning_path = f"{intended_file_path}.reasoning"
+    KAI_LOG.info(f"Writing reasoning to {reasoning_path}")
+    try:
+        with open(reasoning_path, "w") as f:
+            json.dump(updated_file_contents["total_reasoning"], f)
+    except Exception as e:
+        KAI_LOG.error(f"Failed to write reasoning @ {reasoning_path} with error: {e}")
+        KAI_LOG.error(f"Contents: {updated_file_contents}")
+        sys.exit(1)
 
 
 def process_file(file_path, violations, num_impacted_files, count):
-    print(
-        f"File #{count} of {num_impacted_files} - Processing {file_path} which has {len(violations)} violations"
-    )
-
+    start = time.time()
+    KAI_LOG.info(f"File #{count} of {num_impacted_files} - Processing {file_path} which has {len(violations)} violations")
+    # TODO: Revisit processing non Java files
     if not file_path.endswith(".java"):
-        print(f"Skipping {file_path} as it is not a Java file")
+        KAI_LOG.warning(f"Skipping {file_path} as it is not a Java file")
         return
 
     params = collect_parameters(file_path, violations)
     response = generate_fix(params)
-    print(f"\nResponse StatusCode: {response.status_code} for {file_path}\n")
+    KAI_LOG.info(
+        f"Response StatusCode: {response.status_code} for {file_path}\n"
+    )
     updated_file_contents = parse_response(response)
     write_to_disk(file_path, updated_file_contents)
-
+    end = time.time()
+    return f"{end-start}s to process {file_path} with {len(violations)} violations"
 
 def run_demo(report):
     impacted_files = report.get_impacted_files()
     num_impacted_files = len(impacted_files)
-
+    remaining_files = num_impacted_files
     total_violations = sum(len(violations) for violations in impacted_files.values())
     print(f"{num_impacted_files} files with a total of {total_violations} violations.")
 
-    with ThreadPoolExecutor() as executor:
+    max_workers = os.environ.get("KAI_MAX_WORKERS", 8)
+    KAI_LOG.info(f"Running in parallel with {max_workers} workers")
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = []
         for count, (file_path, violations) in enumerate(impacted_files.items(), 1):
             future = executor.submit(
@@ -163,8 +193,15 @@ def run_demo(report):
             futures.append(future)
 
         for future in futures:
-            future.result()
-
+            try:
+                result = future.result()
+                KAI_LOG.info(f"Result:  {result}")
+            except Exception as exc:
+                KAI_LOG.error(f"Generated an exception: {exc}")
+            remaining_files -= 1
+            KAI_LOG.info(
+                f"{remaining_files} files remaining from total of {num_impacted_files}"
+            )
 
 if __name__ == "__main__":
     KAI_LOG.setLevel("info".upper())


### PR DESCRIPTION
- Creates a <srcfilename>.reasoning file as output for each generated file
- Changes client to use KAI_LOG so we have timestamps on output
- Adds start/time to requests to get an idea of how long they are taking


Full client console output: https://gist.github.com/jwmatthews/d1af9b06a29c38ff9dd934225216c228

Sample:
```

INFO - 2024-03-26 13:28:19,794 - [run_demo.py:203 -             run_demo() ] - 2 files remaining from total of 26
INFO - 2024-03-26 13:30:23,443 - [run_demo.py:172 -         process_file() ] - Response StatusCode: 200 for src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java

INFO - 2024-03-26 13:30:23,443 - [run_demo.py:138 -        write_to_disk() ] - Writing updated source code to ./coolstore/src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java
INFO - 2024-03-26 13:30:23,444 - [run_demo.py:150 -        write_to_disk() ] - Writing reasoning to ./coolstore/src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java.reasoning
INFO - 2024-03-26 13:30:23,447 - [run_demo.py:199 -             run_demo() ] - Result:  577.1303780078888s to process src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java with 10 violations
INFO - 2024-03-26 13:30:23,453 - [run_demo.py:203 -             run_demo() ] - 1 files remaining from total of 26
INFO - 2024-03-26 13:30:27,171 - [run_demo.py:172 -         process_file() ] - Response StatusCode: 200 for src/main/java/com/redhat/coolstore/persistence/Resources.java

INFO - 2024-03-26 13:30:27,171 - [run_demo.py:138 -        write_to_disk() ] - Writing updated source code to ./coolstore/src/main/java/com/redhat/coolstore/persistence/Resources.java
INFO - 2024-03-26 13:30:27,172 - [run_demo.py:150 -        write_to_disk() ] - Writing reasoning to ./coolstore/src/main/java/com/redhat/coolstore/persistence/Resources.java.reasoning
INFO - 2024-03-26 13:30:27,173 - [run_demo.py:199 -             run_demo() ] - Result:  1001.1371130943298s to process src/main/java/com/redhat/coolstore/persistence/Resources.java with 6 violations
INFO - 2024-03-26 13:30:27,173 - [run_demo.py:203 -             run_demo() ] - 0 files remaining from total of 26
INFO - 2024-03-26 13:30:27,174 - [run_demo.py:215 -             <module>() ] - Total time to process './analysis/coolstore/output.yaml' was 1001.3894901275635s

```