### PR TITLE
Add retry mechanism and increase timeouts for file resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ run-postgres:
 
 # Can adjust logging level by defining env var: KAI_LOG_LEVEL
 run-server:
-	PYTHONPATH=$(KAI_PYTHON_PATH) gunicorn --timeout 1200 -w $(NUM_WORKERS) --bind localhost:8080 --worker-class aiohttp.GunicornWebWorker 'kai.server:app("$(LOGLEVEL)")'
+	PYTHONPATH=$(KAI_PYTHON_PATH) gunicorn --timeout 3600 -w $(NUM_WORKERS) --bind localhost:8080 --worker-class aiohttp.GunicornWebWorker 'kai.server:app("$(LOGLEVEL)")'
 
 load-data:
 	PYTHONPATH=$(KAI_PYTHON_PATH) python ./kai/incident_store_advanced.py  --config_filepath ./kai/config.toml

--- a/example/run_demo.py
+++ b/example/run_demo.py
@@ -84,7 +84,7 @@ def _generate_fix(params: KaiRequestParams):
         f"{SERVER_URL}/get_incident_solutions_for_file",
         data=params.to_json(),
         headers=headers,
-        timeout=2400,
+        timeout=3600,
     )
     return response
 


### PR DESCRIPTION
Fixes #109 

One of the calls (15 incidents in the file) took 2864s which is why the previous timeouts weren't allowing the demo to finish running.

```
./run_demo.py  1.63s user 0.33s system 0% cpu 1:06:46.71 total
```

This solution won't scale though, we probably need to either chunk incidents (ie only send x at a time) or maybe the work that @JonahSussman is working on will fix it