### PR TITLE
List the violations for a given file

### DIFF
--- a/example/list_violations_for_file.py
+++ b/example/list_violations_for_file.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import sys
+
+# Ensure that we have 'kai' in our import path
+sys.path.append("../../kai")
+from kai import Report
+from kai.kai_logging import KAI_LOG
+
+APP_NAME = "coolstore"
+SAMPLE_APP_DIR = "./coolstore"
+
+### Example to run:
+# ./list_violations_for_file.py "src/main/java/com/redhat/coolstore/service/ShippingService.java"
+if __name__ == "__main__":
+    KAI_LOG.setLevel("info".upper())
+
+    if len(sys.argv) < 2:
+        print("Please provide a file path to list the known violations.")
+        sys.exit(1)
+    target_file = sys.argv[1]
+
+    coolstore_analysis_dir = "./analysis/coolstore/output.yaml"
+    r = Report(coolstore_analysis_dir)
+    impacted_files = r.get_impacted_files()
+    violations = impacted_files.get(target_file, None)
+    if not violations:
+        print(f"File '{target_file}' does not have any violations")
+        sys.exit(0)
+    print(f"File '{target_file}' has the following violations:")
+    for v in violations:
+        print(f"\t{v['ruleset_name']} {v['violation_name']} at line {v['lineNumber']}")


### PR DESCRIPTION
Example of using this to find the violations associated to a given file.

```
$ time ./list_violations_for_file.py "src/main/java/com/redhat/coolstore/service/ShippingService.java"
INFO - 2024-03-27 14:11:55,281 - [report.py:79 -         _read_report() ] - Reading report from ./analysis/coolstore/output.yaml
File 'src/main/java/com/redhat/coolstore/service/ShippingService.java' has the following violations:
	eap8/eap7 javax-to-jakarta-import-00001 at line 6
	eap8/eap7 javax-to-jakarta-import-00001 at line 7
	kai/quarkus remote-ejb-to-quarkus-00000 at line 12
	quarkus/springboot cdi-to-quarkus-00050 at line 11
./list_violations_for_file.py   1.81s user 1.56s system 294% cpu 1.144 total
```


```
$ time ./list_violations_for_file.py "pom.xml"
INFO - 2024-03-27 14:12:22,635 - [report.py:79 -         _read_report() ] - Reading report from ./analysis/coolstore/output.yaml
File 'pom.xml' has the following violations:
	eap7/weblogic/tests/data maven-javax-to-jakarta-00002 at line 
	eap8/eap7 javax-to-jakarta-dependencies-00006 at line 19
	eap8/eap7 javax-to-jakarta-dependencies-00006 at line 25
	eap8/eap7 javax-to-jakarta-dependencies-00007 at line 26
	eap8/eap7 javax-to-jakarta-dependencies-00008 at line 20
	kai/quarkus jms-to-reactive-quarkus-00000 at line 31
	quarkus/springboot javaee-pom-to-quarkus-00010 at line 5
	quarkus/springboot javaee-pom-to-quarkus-00020 at line 5
	quarkus/springboot javaee-pom-to-quarkus-00030 at line 5
	quarkus/springboot javaee-pom-to-quarkus-00040 at line 5
	quarkus/springboot javaee-pom-to-quarkus-00050 at line 5
	quarkus/springboot javaee-pom-to-quarkus-00060 at line 5
	quarkus/springboot quarkus-flyway-00000 at line 36
	quarkus/springboot quarkus-flyway-00010 at line 36

```