### PR TITLE
Add fetching sample apps step to demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ provider = "IBMGranite"
    1. Let this run in background: `make run-server`
       - Please double check that you have `GENAI_KEY=my-secret-api-key-value` defined in the environment variables prior to running the server.
 1. Load data into the database
+   1. Fetch sample apps: `pushd samples; ./fetch_apps.py; popd`
    1. Can run this in current shell, command will run for a ~1 minute and complete
    1. Ensure you are running within our python virtual env: `source env/bin/activate`
    1. `make load-data`


### PR DESCRIPTION
The demo instructions start with cloning the repo.
The first step is `git clone https://github.com/konveyor-ecosystem/kai.git`. If you do this you haven't fetched the sample apps yet. If you run make load without doing it first you'll get the following error:

```
...kai/env/lib64/python3.12/site-packages/git/repo/base.py", line 215, in __init__
    raise NoSuchPathError(epath)
git.exc.NoSuchPathError: /home/jason/Documents/go/src/github.com/konveyor-ecosystem/kai/samples/sample_repos/bmt
make: *** [Makefile:16: load-data] Error 1
```