### PR TITLE
Make parsing of LLM response more robust

### DIFF
--- a/example/run_demo.py
+++ b/example/run_demo.py
@@ -156,12 +156,23 @@ def write_to_disk(file_path, updated_file_contents):
         KAI_LOG.error(f"Failed to write reasoning @ {reasoning_path} with error: {e}")
         KAI_LOG.error(f"Contents: {updated_file_contents}")
         sys.exit(1)
+
+    prompts_path = f"{intended_file_path}.prompts"
+    KAI_LOG.info(f"Writing prompts to {prompts_path}")
+    try:
+        with open(prompts_path, "w") as f:
+            f.write("\n---\n".join(updated_file_contents["used_prompts"]))
+    except Exception as e:
+        KAI_LOG.error(f"Failed to write prompts @ {prompts_path} with error: {e}")
+        KAI_LOG.error(f"Contents: {updated_file_contents}")
+        sys.exit(1)
+
     if updated_file_contents.get("llm_results"):
         llm_result_path = f"{intended_file_path}.llm_result"
         KAI_LOG.info(f"Writing llm_result to {llm_result_path}")
         try:
             with open(llm_result_path, "w") as f:
-                f.write("\n\n".join(updated_file_contents["llm_results"]))
+                f.write("\n---\n".join(updated_file_contents["llm_results"]))
         except Exception as e:
             KAI_LOG.error(
                 f"Failed to write llm_result @ {llm_result_path} with error: {e}"

--- a/example/run_demo.py
+++ b/example/run_demo.py
@@ -50,6 +50,7 @@ class KaiRequestParams:
     file_name: str
     file_contents: str
     incidents: list[KaiIncident]
+    include_llm_results: bool = True
 
     @staticmethod
     def from_incidents(
@@ -155,6 +156,18 @@ def write_to_disk(file_path, updated_file_contents):
         KAI_LOG.error(f"Failed to write reasoning @ {reasoning_path} with error: {e}")
         KAI_LOG.error(f"Contents: {updated_file_contents}")
         sys.exit(1)
+    if updated_file_contents.get("llm_results"):
+        llm_result_path = f"{intended_file_path}.llm_result"
+        KAI_LOG.info(f"Writing reasoning to {llm_result_path}")
+        try:
+            with open(llm_result_path, "w") as f:
+                f.write("\n\n".join(updated_file_contents["llm_results"]))
+        except Exception as e:
+            KAI_LOG.error(
+                f"Failed to write llm_result @ {llm_result_path} with error: {e}"
+            )
+            KAI_LOG.error(f"Contents: {updated_file_contents}")
+            sys.exit(1)
 
 
 def process_file(file_path, violations, num_impacted_files, count):

--- a/example/run_demo.py
+++ b/example/run_demo.py
@@ -158,7 +158,7 @@ def write_to_disk(file_path, updated_file_contents):
         sys.exit(1)
     if updated_file_contents.get("llm_results"):
         llm_result_path = f"{intended_file_path}.llm_result"
-        KAI_LOG.info(f"Writing reasoning to {llm_result_path}")
+        KAI_LOG.info(f"Writing llm_result to {llm_result_path}")
         try:
             with open(llm_result_path, "w") as f:
                 f.write("\n\n".join(updated_file_contents["llm_results"]))

--- a/kai/pydantic_models.py
+++ b/kai/pydantic_models.py
@@ -1,6 +1,10 @@
 import re
 
 from pydantic import BaseModel
+from pygments import lexers
+from pygments.util import ClassNotFound
+
+from kai.kai_logging import KAI_LOG
 
 
 class FileSolutionContent(BaseModel):
@@ -8,15 +12,56 @@ class FileSolutionContent(BaseModel):
     updated_file: str
 
 
-# TODO: Sometimes this will fail. Why?
-def parse_file_solution_content(content: str) -> FileSolutionContent:
+def guess_language(code: str, filename: str = None) -> str:
+    try:
+        if filename:
+            lexer = lexers.guess_lexer_for_filename(filename, code)
+            KAI_LOG.debug(f"{filename} classified as {lexer.aliases[0]}")
+        else:
+            lexer = lexers.guess_lexer(code)
+            KAI_LOG.debug(f"Code content classified as {lexer.aliases[0]}\n{code}")
+        return lexer.aliases[0]
+    except ClassNotFound:
+        KAI_LOG.debug(
+            f"Code content for filename {filename} could not be classified\n{code}"
+        )
+        return "unknown"
+
+
+def parse_file_solution_content(language: str, content: str) -> FileSolutionContent:
     reasoning_pattern = r"## Reasoning\s+(.+?)(?=##|$)"
-    updated_file_pattern = r"```(?:\w+)?\s+(.+?)```"
+    code_block_pattern = r"```(?:\w+)?\s+(.+?)```"
 
     reasoning_match = re.search(reasoning_pattern, content, re.DOTALL)
-    updated_file_match = re.search(updated_file_pattern, content, re.DOTALL)
-
     reasoning = reasoning_match.group(1).strip() if reasoning_match else ""
-    updated_file = updated_file_match.group(1).strip() if updated_file_match else ""
+    code_block_matches = re.findall(code_block_pattern, content, re.DOTALL)
+
+    matching_blocks = []
+    for block in code_block_matches:
+        guessed_language = guess_language(block)
+        if language == guessed_language:
+            matching_blocks.append(block)
+
+    if matching_blocks:
+        # If multiple matches default to first
+        updated_file = matching_blocks[0].strip()
+        if len(matching_blocks) > 1:
+            KAI_LOG.debug(
+                f"Multiple matching codeblocks found, defaulting to first {matching_blocks}"
+            )
+        else:
+            KAI_LOG.debug(f"Found single matching codeblock \n{updated_file}")
+    elif code_block_matches:
+        # fallback to first discovered codeblock
+        updated_file = code_block_matches[0]
+        if len(code_block_matches) > 1:
+            KAI_LOG.debug(
+                f"Multiple codeblocks found, defaulting to first {code_block_matches}"
+            )
+        else:
+            KAI_LOG.debug(f"Found single codeblock \n{updated_file}")
+    else:
+        updated_file = ""
+        KAI_LOG.warn("No codeblocks detected in LLM response")
 
     return FileSolutionContent(reasoning=reasoning, updated_file=updated_file)

--- a/kai/pydantic_models.py
+++ b/kai/pydantic_models.py
@@ -63,5 +63,6 @@ def parse_file_solution_content(language: str, content: str) -> FileSolutionCont
     else:
         updated_file = ""
         KAI_LOG.warn("No codeblocks detected in LLM response")
+        KAI_LOG.debug(content)
 
     return FileSolutionContent(reasoning=reasoning, updated_file=updated_file)

--- a/kai/pydantic_models.py
+++ b/kai/pydantic_models.py
@@ -34,7 +34,13 @@ def parse_file_solution_content(language: str, content: str) -> FileSolutionCont
 
     reasoning_match = re.search(reasoning_pattern, content, re.DOTALL)
     reasoning = reasoning_match.group(1).strip() if reasoning_match else ""
-    code_block_matches = re.findall(code_block_pattern, content, re.DOTALL)
+
+    # Only search under the Updated File header if it exists
+    if "## Updated File" in content:
+        updated_file_content = content.split("## Updated File")[1]
+    else:
+        updated_file_content = content
+    code_block_matches = re.findall(code_block_pattern, updated_file_content, re.DOTALL)
 
     matching_blocks = []
     for block in code_block_matches:

--- a/kai/server.py
+++ b/kai/server.py
@@ -519,6 +519,10 @@ async def get_incident_solutions_for_file(request: Request):
                 content = parse_file_solution_content(
                     src_file_language, llm_result.content
                 )
+                if not content.updated_file:
+                    raise Exception(
+                        f"Error in LLM Response: The LLM did not provide an updated file for {request_json['file_name']}"
+                    )
                 if request_json.get("include_llm_results"):
                     llm_results.append(llm_result.content)
 


### PR DESCRIPTION
Fixes #122 
- Add language guesser and use it to more intelligently select code blocks from response
- Don't count incomplete responses as successful
  - Retries when updated file content is not parsed
  - Only attempts to find code block content underneath the Updated File header in order to avoid grabbing extra info from reasoning
- Add support for returning LLM results directly on the server and saving it from the demo client