### PR TITLE
Process non-java files in demo and log what model is actually used in a result

### DIFF
--- a/example/run_demo.py
+++ b/example/run_demo.py
@@ -171,7 +171,9 @@ def write_to_disk(file_path, updated_file_contents):
         llm_result_path = f"{intended_file_path}.llm_result"
         KAI_LOG.info(f"Writing llm_result to {llm_result_path}")
         try:
+            model_id = updated_file_contents.get("model_id", "unknown")
             with open(llm_result_path, "w") as f:
+                f.write(f"Model ID: {model_id}\n")
                 f.write("\n---\n".join(updated_file_contents["llm_results"]))
         except Exception as e:
             KAI_LOG.error(
@@ -186,10 +188,6 @@ def process_file(file_path, violations, num_impacted_files, count):
     KAI_LOG.info(
         f"File #{count} of {num_impacted_files} - Processing {file_path} which has {len(violations)} violations"
     )
-    # TODO: Revisit processing non Java files
-    if not file_path.endswith(".java"):
-        KAI_LOG.warning(f"Skipping {file_path} as it is not a Java file")
-        return
 
     params = collect_parameters(file_path, violations)
     response = generate_fix(params)

--- a/kai/server.py
+++ b/kai/server.py
@@ -550,6 +550,7 @@ async def get_incident_solutions_for_file(request: Request):
         "updated_file": updated_file,
         "total_reasoning": total_reasoning,
         "used_prompts": used_prompts,
+        "model_id": request.app["model_provider"].get_current_model_id(),
     }
     if request_json.get("include_llm_results"):
         response["llm_results"] = llm_results


### PR DESCRIPTION
With this PR we will run the demo against pom.xml, .properties, and other non-java files.

This will also write a line in each 'result' file to confirm the model used.
In this example I was configured with:

```
INFO - 2024-03-29 09:42:17,795 - [server.py:571 -                  app() ] - Config loaded: {'embeddings': {'todo': True},
 'models': {'args': {'model_id': 'codellama/codellama-34b-instruct'},
            'provider': 'IBMOpenSource'},
```

Yet we can see it defaulted to `meta-llama/llama-2-13b-chat`.   PR #127 will help to improve this so in future we won't silently default to a different model than what is configured


```
$ head pom.xml.llm_result 
Model ID: meta-llama/llama-2-13b-chat


# Java EE to Quarkus Migration

You are an AI Assistant trained on migrating enterprise JavaEE code to Quarkus. I will give you an example of a JavaEE file and you will give me the Quarkus equivalent.
```
