### PR TITLE
If re-running fetch_apps.py instruct user to delete sample_repos dir

### DIFF
--- a/samples/config.py
+++ b/samples/config.py
@@ -1,9 +1,4 @@
 repos = {
-    "eap-coolstore-monolith": [
-        "https://github.com/mathianasj/eap-coolstore-monolith.git",
-        "main",
-        "quarkus-migration",
-    ],
     "kitchensink": [
         "https://github.com/tqvarnst/jboss-eap-quickstarts.git",
         "7.1",

--- a/samples/fetch_apps.py
+++ b/samples/fetch_apps.py
@@ -11,6 +11,10 @@ from config import repos
 def fetch_sample_apps():
     for repo in repos:
         print(f"Cloning {repo}...")
+        if os.path.exists(f"sample_repos/{repo}"):
+            print(f"*** Exiting since 'sample_repos/{repo}' already exists")
+            print("*** Delete 'sample_repos' and rerun this script")
+            sys.exit(1)
         gitCloneStatus = subprocess.run(  # trunk-ignore(bandit)
             ["git", "clone", repos[repo][0], f"sample_repos/{repo}"]
         )


### PR DESCRIPTION
There was a potential point of confusion if someone re-ran fetch_apps.py and already had sample_repos populated, this is intended to give them guidance so they know they should just delete the sample_repos directory and re-run

Also remove the older coolstore repo which we no longer use


Prior behavior when sample_repos was populated
```
$ time ./fetch_apps.py 
Cloning eap-coolstore-monolith...
fatal: destination path 'sample_repos/eap-coolstore-monolith' already exists and is not an empty directory.
Error cloning eap-coolstore-monolith
*** Exiting since we couldnt clone 'eap-coolstore-monolith'
./fetch_apps.py  0.02s user 0.02s system 52% cpu 0.091 total
```

New behavior when sample_repos is populated
```
$ time ./fetch_apps.py 
Cloning kitchensink...
*** Exiting since 'sample_repos/kitchensink' already exists
*** Delete 'sample_repos' and rerun this script
./fetch_apps.py  0.02s user 0.01s system 61% cpu 0.042 total

```
