### PR TITLE
Naive incident store fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CWD := $(shell pwd)
 KAI_PYTHON_PATH="$(CWD)/kai:$(PYTHONPATH)"
 LOGLEVEL ?= info
 NUM_WORKERS ?= 8
+DROP_TABLES ?= False
 
 run-postgres:
 	$(CONTAINER_RUNTIME) run -it -v data:/var/lib/postgresql/data -e POSTGRES_USER=kai -e POSTGRES_PASSWORD=dog8code -e POSTGRES_DB=kai -p 5432:5432 docker.io/pgvector/pgvector:pg15
@@ -13,4 +14,4 @@ run-server:
 	PYTHONPATH=$(KAI_PYTHON_PATH) gunicorn --timeout 3600 -w $(NUM_WORKERS) --bind localhost:8080 --worker-class aiohttp.GunicornWebWorker 'kai.server:app("$(LOGLEVEL)")'
 
 load-data:
-	PYTHONPATH=$(KAI_PYTHON_PATH) python ./kai/incident_store_advanced.py  --config_filepath ./kai/config.toml
+	PYTHONPATH=$(KAI_PYTHON_PATH) python ./kai/incident_store_advanced.py --loglevel $(LOGLEVEL) --config_filepath ./kai/config.toml --drop_tables $(DROP_TABLES)


### PR DESCRIPTION
NOTE: With the new solved incidents being included, the prompts can get too long and might fail. I added a piece of code to remove the solved incidents when the request fails. A better fix would be to create a new method on the model provider base class to parse _why_ it failed. Feel free to block this merge if you guys want to go that approach.