### PR TITLE
:ghost: Unpin python version in evaluation action

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@main
         with:
-          python-version: 3.12.3
+          python-version: 3.12
       - name: Update environment
         run: |
           echo "MAX_NEW_TOKENS=${{ matrix.evaluation.max_new_tokens }}" >> $GITHUB_ENV


### PR DESCRIPTION
Pinning to 3.12.3 should no longer be necessary.

https://github.com/konveyor-ecosystem/kai/issues/215
https://github.com/konveyor-ecosystem/kai/pull/216