### PR TITLE
adding support for handling hash value passed from ide

### DIFF
--- a/kai/llm_io_handler.py
+++ b/kai/llm_io_handler.py
@@ -160,6 +160,7 @@ async def get_incident_solutions_for_file(
     include_solved_incidents: Optional[bool] = True,
     include_llm_results: bool = False,
     demo_mode: bool = False,
+    hash: str = "nohash",
 ):
 
     src_file_language = guess_language(file_contents, filename=file_name)
@@ -273,6 +274,7 @@ async def get_incident_solutions_for_file(
         "used_prompts": used_prompts,
         "model_id": model_id,
         "additional_information": additional_info,
+        "hash": hash,
     }
     if include_llm_results:
         response["llm_results"] = llm_results

--- a/kai/server.py
+++ b/kai/server.py
@@ -232,6 +232,7 @@ async def get_incident_solutions_for_file(request: Request):
             trace,
             request.app["model_provider"],
             request.app["incident_store"],
+            params.hash,
             params.file_contents,
             params.file_name,
             params.application_name,


### PR DESCRIPTION
Need a mechanism to discard the response from backend, if the user has cancelled the kai-fix or kantra in the front end. We are adding a simple hash to the request and storing that in the front end. The idea is to match the hash returned with response from Kai and verify if the request needs to be processed or discarded. 